### PR TITLE
Only install HDF5 in _libs_ versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,17 @@ xenial_cmake3.5 -> xenial_libs_cmake3.5 -> xenial_libs_cmake3.10
 
 Centos 7 with the minimal set of dependencies installed to build the full PDI
 distribution in "embedded" mode, except for cmake.
-It enables the SCL, EPEL and home:pdi repositories and activates devtoolset-7
-by default.
+It enables the SCL, EPEL and pdi repositories and activates devtoolset-7 by
+default.
 
 ## centos_cmake3.5
 
 centos_base extended with the minimal dependencies to build the full PDI 
 distribution with cmake-3.5 (without running the tests):
 * cmake 3.5
-* hdf5 because HDF5 build requires cmake-3.10
 
 Used for PDI "embedded" build with cmake 3.5 (using all libs embedded in the PDI
-distribution except for HDF5 from the docker image)
+distribution)
 
 ## centos_cmake3.10
 
@@ -52,15 +51,15 @@ on embedded dependencies:
 * doxygen,
 * flowvr,
 * fti,
+* netcdf,
+* paraconf,
 * pybind11,
-* sionlib.
+* sionlib,
+* spdlog.
 
 Installation of the libs that are available as packages:
 * hdf5,
-* libparaconf,
-* libyaml,
-* netcdf,
-* spdlog.
+* libyaml.
 
 Used for PDI "system" build and tests with cmake 3.10 (using all libs from the
 docker image)
@@ -68,22 +67,14 @@ docker image)
 ## centos_libs_cmake3.5
 
 Integration of the libraries built inside centos_libs_cmake3.10 into 
-centos_cmake3.5:
-* astyle,
-* bpp,
-* flowvr,
-* fti,
-* pybind11,
-* sionlib.
+centos_cmake3.5.
 
 Installation of the libs that are available as packages:
-* libparaconf,
-* libyaml,
-* netcdf,
-* spdlog.
+* hdf5,
+* libyaml.
 
-
-Used for PDI "system" build with cmake 3.5 (using all libs from the docker image)
+Used for PDI "system" build with cmake 3.5 (using all libs from the docker
+image)
 
 ## xenial_cmake3.5
 
@@ -91,7 +82,7 @@ Ubuntu Xenial with the minimal set of dependencies installed to build the full
 PDI distribution in "embedded" mode (without running the tests).
 
 Used for PDI "embedded" build with cmake 3.5 (using all libs embedded in the PDI
-distribution except for HDF5 from the docker image)
+distribution, except for SIONlib)
 
 ## xenial_cmake3.10
 
@@ -106,22 +97,21 @@ in the PDI distribution)
 
 Building of the dependencies required for the PDI distribution without relying
 on embedded dependencies:
+* doxygen,
 * flowvr,
 * fti,
-* netcdf,
-* sionlib.
+* netcdf.
 
 Installation of the libs that are available as packages:
 * astyle,
-* doxygen,
-* libhdf5-mpich-dev,
-* libparaconf-dev,
-* libspdlog-dev,
-* pybind11-dev,
-* python,
+* hdf5,
+* paraconf,
+* spdlog,
+* pybind11,
 * zpp.
 
-Used for PDI "system" build with cmake 3.5 (using all libs from the docker image)
+Used for PDI "system" build with cmake 3.5 (using all libs from the docker
+image)
 
 ## xenial_libs_cmake3.10
 

--- a/centos_cmake3.10/Dockerfile
+++ b/centos_cmake3.10/Dockerfile
@@ -1,6 +1,4 @@
-FROM pdidevel/centos_base:latest
-
-# Install CMake 3.10+ and stuff needed for tests
+FROM pdidevel/centos_base
 
 USER 0
 

--- a/centos_cmake3.5/Dockerfile
+++ b/centos_cmake3.5/Dockerfile
@@ -1,12 +1,7 @@
-FROM pdidevel/centos_base:latest
-
-# Install HDF5 that requires CMake 10 in embedded mode + CMake 3.5
+FROM pdidevel/centos_base AS builder
 
 USER 0
 
-RUN yum install -y --setopt=tsflags=nodocs \
-    hdf5-openmpi3-devel \
- && yum clean all -y
 RUN curl -Lso cmake.tar.gz https://cmake.org/files/v3.5/cmake-3.5.2.tar.gz \
  && tar -xzf cmake.tar.gz \
  && rm cmake.tar.gz \
@@ -16,5 +11,11 @@ RUN curl -Lso cmake.tar.gz https://cmake.org/files/v3.5/cmake-3.5.2.tar.gz \
  && make install \
  && cd \
  && rm -r cmake*
+
+FROM pdidevel/centos_cmake3.10
+
+USER 0
+
+COPY --from=builder /usr/local /usr/local
 
 USER 1001

--- a/centos_libs_cmake3.5/Dockerfile
+++ b/centos_libs_cmake3.5/Dockerfile
@@ -5,8 +5,8 @@ USER 0
 COPY --from=pdidevel/centos_libs_cmake3.10 /usr/local /usr/local
 
 RUN yum install -y --setopt=tsflags=nodocs \
+    hdf5-openmpi3-devel \
     libyaml-devel \
-    spdlog-devel \
  && yum clean all -y
 RUN echo '. /usr/local/bin/flowvr-suite-config.sh' > /etc/profile.d/zzz_enable_flowvr.sh
 

--- a/xenial_cmake3.10/Dockerfile
+++ b/xenial_cmake3.10/Dockerfile
@@ -2,11 +2,6 @@ FROM pdidevel/xenial_cmake3.5 AS builder
 
 USER 0
 
-RUN apt-get update -y \
- && apt-get upgrade -y \
- && apt-get install -y \
-    curl
-
 RUN curl -Lso cmake.tar.gz https://cmake.org/files/v3.10/cmake-3.10.0.tar.gz \
  && tar -xf cmake.tar.gz \
  && cd cmake* \
@@ -23,13 +18,8 @@ COPY --from=builder /usr/local /usr/local
 RUN apt-get update -y \
  && apt-get purge -y \
     cmake \
-    libhdf5-mpich-dev \
  && apt-get autoremove -y \
  && apt-get upgrade -y \
- && apt-get install -y \
-    python3-numpy \
-    python3-pip \
-    libmpich-dev \
  && apt-get clean \
  && apt-get autoclean \
  && pip3 install --upgrade pip \

--- a/xenial_cmake3.10/Dockerfile
+++ b/xenial_cmake3.10/Dockerfile
@@ -22,7 +22,6 @@ RUN apt-get update -y \
  && apt-get upgrade -y \
  && apt-get clean \
  && apt-get autoclean \
- && pip3 install --upgrade pip \
  && pip3 install --no-cache-dir mpi4py \
  && ldconfig
 

--- a/xenial_cmake3.5/Dockerfile
+++ b/xenial_cmake3.5/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update -y \
     python3-dev \
     python3-numpy \
     python3-pip \
+    python3-setuptools \
     python3-yaml \
     rsync \
     unzip \

--- a/xenial_cmake3.5/Dockerfile
+++ b/xenial_cmake3.5/Dockerfile
@@ -19,7 +19,6 @@ RUN apt-get update -y \
     flex \
     freeglut3-dev \
     gfortran \
-    libhdf5-mpich-dev \
     libhwloc-dev \
     libmpich-dev \
     libz-dev \
@@ -29,6 +28,7 @@ RUN apt-get update -y \
     python-yaml \
     python3-dev \
     python3-numpy \
+    python3-pip \
     python3-yaml \
     rsync \
     unzip \
@@ -39,18 +39,11 @@ RUN apt-get update -y \
  && apt-get install -y \
  && apt-get upgrade -y \
  && rm *.deb \
- && apt-get purge -y \
-    curl \
  && apt-get autoremove -y \
  && apt-get clean \
  && apt-get autoclean
 
 FROM prebuild as builder
-
-RUN apt-get update -y \
- && apt-get upgrade -y \
- && apt-get install -y \
-    curl
 
 RUN curl -Lso sionlib.tar.gz 'http://apps.fz-juelich.de/jsc/sionlib/download.php?version=1.7.6' \
  && tar -xf sionlib.tar.gz \

--- a/xenial_libs_cmake3.10/Dockerfile
+++ b/xenial_libs_cmake3.10/Dockerfile
@@ -2,11 +2,6 @@ FROM pdidevel/xenial_libs_cmake3.5 AS builder
 
 USER 0
 
-RUN apt-get update -y \
- && apt-get upgrade -y \
- && apt-get install -y \
-    curl
-
 RUN curl -Lso cmake.tar.gz https://cmake.org/files/v3.10/cmake-3.10.0.tar.gz \
  && tar -xf cmake.tar.gz \
  && cd cmake* \
@@ -25,10 +20,6 @@ RUN apt-get update -y \
     cmake \
  && apt-get autoremove -y \
  && apt-get upgrade -y \
- && apt-get install -y \
-    python3-numpy \
-    python3-pip \
-    libmpich-dev \
  && apt-get clean \
  && apt-get autoclean \
  && pip3 install --upgrade pip \

--- a/xenial_libs_cmake3.10/Dockerfile
+++ b/xenial_libs_cmake3.10/Dockerfile
@@ -22,7 +22,6 @@ RUN apt-get update -y \
  && apt-get upgrade -y \
  && apt-get clean \
  && apt-get autoclean \
- && pip3 install --upgrade pip \
  && pip3 install --no-cache-dir mpi4py \
  && ldconfig
 

--- a/xenial_libs_cmake3.5/Dockerfile
+++ b/xenial_libs_cmake3.5/Dockerfile
@@ -2,11 +2,6 @@ FROM pdidevel/xenial_cmake3.5 AS builder
 
 USER 0
 
-RUN apt-get update -y \
- && apt-get upgrade -y \
- && apt-get install -y \
-    curl
-
 RUN curl -Lso doxygen.tar.gz https://sourceforge.net/projects/doxygen/files/rel-1.8.13/doxygen-1.8.13.src.tar.gz \
  && tar -xf doxygen.tar.gz \
  && cd doxygen* \
@@ -48,6 +43,7 @@ RUN apt-get update -y \
  && apt-get upgrade -y \
  && apt-get install -y \
     astyle \
+    libhdf5-mpich-dev \
     libparaconf-dev \
     libspdlog-dev \
     pybind11-dev \

--- a/xenial_libs_cmake3.5/Dockerfile
+++ b/xenial_libs_cmake3.5/Dockerfile
@@ -2,6 +2,18 @@ FROM pdidevel/xenial_cmake3.5 AS builder
 
 USER 0
 
+RUN apt-get update -y \
+ && apt-get upgrade -y \
+ && apt-get install -y \
+    astyle \
+    libhdf5-mpich-dev \
+    libparaconf-dev \
+    libspdlog-dev \
+    pybind11-dev \
+    zpp \
+ && apt-get clean \
+ && apt-get autoclean
+
 RUN curl -Lso doxygen.tar.gz https://sourceforge.net/projects/doxygen/files/rel-1.8.13/doxygen-1.8.13.src.tar.gz \
  && tar -xf doxygen.tar.gz \
  && cd doxygen* \


### PR DESCRIPTION
As soon as https://gitlab.maisondelasimulation.fr/pdidev/pdi/-/merge_requests/264 is merged, we don't need HDF5 in cmake-3.5 images anymore and can build the embedded one. This branch should then be merged to master